### PR TITLE
Use v1 tag for asdf action instead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
-    - uses: asdf-vm/actions/plugin-test@v1.0.0
+    - uses: asdf-vm/actions/plugin-test@v1
       with:
         command: clusterctl version
       env:


### PR DESCRIPTION
We adhere to semantic versioning, it's safe to use the major version (v1) in your workflow.

```yml
steps:
  # Reference the major version of a release (most recommended)
  - uses: asdf-vm/actions/plugin-test@v1
  # Reference a specific commit (most strict)
  - uses: asdf-vm/actions/plugin-test@a3684980becbd89dd51423e4df5951e56d644e5b
  # Reference a semver version of a release (not recommended)
  - uses: asdf-vm/actions/plugin-test@v1.0.0
  # Reference a branch (most dangerous)
  - uses: asdf-vm/actions/plugin-test@master
```